### PR TITLE
Changed the "posts" query to search for a tag

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -77,7 +77,7 @@ docpadConfig = {
 
 		# This one, will fetch in all documents that have the tag "post" specified in their meta data
 		posts: (database) ->
-			database.findAllLive({relativeOutDirPath:'posts'},[date:-1])
+			database.findAllLive({tags: $has: ['post']}}, [date:-1])
 
 
 	# =================================


### PR DESCRIPTION
Current implementation only grabs direct children of the 
`posts` directory which breaks when you add sub-folders.

Updated implementation to avoid this problem and so behaviour
matches comment directly above...
