### PR TITLE
Syntax error in docpad.coffee

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -77,7 +77,7 @@ docpadConfig = {
 
 		# This one, will fetch in all documents that have the tag "post" specified in their meta data
 		posts: (database) ->
-			database.findAllLive({tags: $has: ['post']}}, [date:-1])
+			database.findAllLive({tags: $has: ['post']}, [date:-1])
 
 
 	# =================================


### PR DESCRIPTION
Syntax error crept in: extra close brace.

How did this one make it through the last review? No tests, I suppose.
