### PR TITLE
Removed log.js & modernizer and added boostrap.min.js

### DIFF
--- a/src/layouts/default.html.eco
+++ b/src/layouts/default.html.eco
@@ -65,6 +65,6 @@
 	</div><!-- /container -->
 
 	<!-- Scripts -->
-	<%- @getBlock('scripts').add(["/vendor/jquery.js","/vendor/log.js","/vendor/modernizr.js","/scripts/script.js"]).toHTML() %>
+	<%- @getBlock('scripts').add(["/vendor/jquery.js","/vendor/twitter-bootstrap/js/bootstrap.min.js","/scripts/script.js"]).toHTML() %>
 </body>
 </html>


### PR DESCRIPTION
from #docpad irc
[20:57] mikeumus hey balupton, you may want to consider including bootstrap.min.js in the getBlock('scripts') in default layout for the bootstrap skeleton
[20:57] mikeumus just 2 cents
[20:58] balupton good idea, want to do a pull request?
[20:58] mikeumus **otherwise you can't use the bootstrap js by default**
[20:58] mikeumus I can sure give it a shot
[20:59] balupton :) awesome
[20:59] mikeumus 8)

[21:16] mikeumus I don't know if docpad uses log.js or modernizer
[21:18] ashnur nope
[21:18] mikeumus if not then there's the light-weight node.js philosophy argument that maybe these should be lest out of the skeleton? but ... which raises another question, If I removed them from default in my pull req, are you able to partial merges? I only saw the big green merge button in Github's example which doesn't look like it.
[21:18] ashnu> the skeleton might use it
[21:19] mikeumus from my working with it I don't think I've seen any uses of it yet the last two days but I don't know 
