### PR TITLE
Added related plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"docpad-plugin-less": "2.x",
 		"docpad-plugin-marked": "2.x",
 		"docpad-plugin-partials": "2.x",
+		"docpad-plugin-related": "2.x",
 		"docpad-plugin-stylus": "2.x",
 		"docpad-plugin-text": "2.x"
 	},


### PR DESCRIPTION
Solved cant see [relatedDocuement](https://github.com/docpad/twitter-bootstrap.docpad/blob/master/src/layouts/post.html.eco) :)

I additionally generates a conflict with docpad.coffee line [#80](https://github.com/docpad/twitter-bootstrap.docpad/blob/master/docpad.coffee#L80) 
always show post's pages with tag 'post' using related plugin, but im solve adding meta:

```

---
name: post

---
```

and

```
database.findAllLive({name: $has: ['post']}, [date:-1])
```

I do not know if this is the best practice / solution or is a conlicto really?

bye
