### PR TITLE
Update post.html.eco

### DIFF
--- a/src/layouts/post.html.eco
+++ b/src/layouts/post.html.eco
@@ -8,16 +8,16 @@ layout: default
 </article>
 
 <footer>
-	<% if  @document.relatedDocuments and @document.relatedDocuments.length: %>
-	<section id="related">
-		<h3>Related Posts</h3>
-		<nav class="linklist">
-			<% for document in @document.relatedDocuments: %>
-				<li><span><%= document.date.toDateString() %></span>
-				&raquo;
-				<a href="<%= document.url %>"><%= document.title %></a></li>
-			<% end %>
-		</nav>
-	</section>
+	<% if @getRelatedDocuments(): %>
+		<section id="related">
+			<h3>Related Posts</h3>
+			<nav class="linklist">
+				<% for document in @getRelatedDocuments(): %>
+					<li><span><%= document.date.toDateString() %></span>
+					&raquo;
+					<a href="<%= document.url %>"><%= document.title %></a></li>
+				<% end %>
+			</nav>
+		</section>
 	<% end %>
 </footer>


### PR DESCRIPTION
Existing @documents.relatedDocuments call on post template footer doesn't appear to work. Patched code appears to work with docpad-plugin-related v2.2.2