### PR TITLE
Fixed downloader path in docpad.coffee and twitter bootstrap path in …

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -100,7 +100,7 @@ docpadConfig = {
 			downloads: [
 				{
 					name: 'Bootstrap'
-					path: 'src/files/vendor/twitter-bootstrap'
+					path: 'src/static/vendor/twitter-bootstrap'
 					url: 'https://codeload.github.com/twbs/bootstrap/tar.gz/master'
 					tarExtractClean: true
 				}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "npm": "1.2"
   },
   "dependencies": {
-    "docpad": "~6.74.0",
+    "docpad": "~6.78.1",
     "docpad-plugin-cleanurls": "~2.7.0",
     "docpad-plugin-coffeescript": "~2.5.0",
     "docpad-plugin-downloader": "~2.1.4",

--- a/src/render/styles/twitter-bootstrap.css.less
+++ b/src/render/styles/twitter-bootstrap.css.less
@@ -1,1 +1,1 @@
-@import "../../files/vendor/twitter-bootstrap/less/bootstrap";
+@import "../../static/vendor/twitter-bootstrap/less/bootstrap";


### PR DESCRIPTION
…src/styles to read/write from static/ rather than files/
